### PR TITLE
Update Testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ $ yurt init
 ```
 
 `YURT_ENV=dev` makes yurt set up a separate VM for development. When set, all commands refer to this development VM.
+Similarly, you can set `YURT_ENV=test` to run tests in yet another separate VM with `python -m unittest`.
 
 Please create an issue if something does not work for you. Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 

--- a/testing/test_lxc.py
+++ b/testing/test_lxc.py
@@ -1,20 +1,18 @@
-import unittest
 import logging
-import os
 
-from yurt import lxc, util
+from testing import util
+from yurt import util as yurt_util
+from yurt import lxc
 
-from test.yurt_test_util import YurtTest, ping
 
-
-class LXCTest(YurtTest):
+class LXCTest(util.YurtTest):
 
     def test_launch(self):
-        instance_name = f"test-instance-{util.random_string()}"
+        util.mark("test_launch")
 
-        logging.info(f"Test launch: {instance_name}.")
+        instance_name = util.generate_instance_name()
         lxc.launch("images", "alpine/3.10", instance_name)
-        instance = util.find(
+        instance = yurt_util.find(
             lambda i: i["Name"] == instance_name and i["Status"] == "Running",
             lxc.list_(),
             None
@@ -22,12 +20,13 @@ class LXCTest(YurtTest):
         self.assertIsNotNone(instance)
 
     def test_stop(self):
-        instance_name = f"test-instance-{util.random_string()}"
+        util.mark("test_stop")
+
+        instance_name = util.generate_instance_name()
         lxc.launch("images", "alpine/3.10", instance_name)
 
-        logging.info(f"Test stop: {instance_name}.")
         lxc.stop([instance_name])
-        instance = util.find(
+        instance = yurt_util.find(
             lambda i: i["Name"] == instance_name and i["Status"] == "Stopped",
             lxc.list_(),
             None
@@ -35,13 +34,14 @@ class LXCTest(YurtTest):
         self.assertIsNotNone(instance)
 
     def test_start(self):
-        instance_name = f"test-instance-{util.random_string()}"
+        util.mark("test_start")
+
+        instance_name = util.generate_instance_name()
         lxc.launch("images", "alpine/3.10", instance_name)
         lxc.stop([instance_name])
 
-        logging.info(f"Test start: {instance_name}.")
         lxc.start([instance_name])
-        instance = util.find(
+        instance = yurt_util.find(
             lambda i: i["Name"] == instance_name and i["Status"] == "Running",
             lxc.list_(),
             None
@@ -49,12 +49,14 @@ class LXCTest(YurtTest):
         self.assertIsNotNone(instance)
 
     def test_delete(self):
-        instance_name = f"test-instance-{util.random_string()}"
+        util.mark("test_delete")
+
+        instance_name = util.generate_instance_name()
         lxc.launch("images", "alpine/3.10", instance_name)
         lxc.stop([instance_name])
         lxc.delete([instance_name])
 
-        instance = util.find(
+        instance = yurt_util.find(
             lambda i: i["Name"] == instance_name,
             lxc.list_(),
             None
@@ -62,9 +64,11 @@ class LXCTest(YurtTest):
         self.assertIsNone(instance)
 
     def test_ping_from_host(self):
-        instance_name = f"test-instance-{util.random_string()}"
+        util.mark("test_ping_from_host")
+
+        instance_name = util.generate_instance_name()
         lxc.launch("images", "alpine/3.10", instance_name)
-        instance = util.find(
+        instance = yurt_util.find(
             lambda i: i["Name"] == instance_name and i["Status"] == "Running",
             lxc.list_(),
             None
@@ -73,18 +77,15 @@ class LXCTest(YurtTest):
 
         logging.info(f"Test ping: {instance_name}")
         ip_address = instance["IP Address"]
-        self.assertTrue(ping(ip_address))
+        self.assertTrue(util.ping(ip_address))
 
     def test_ping_between_instances(self):
-        instance1_name = f"test-instance-{util.random_string()}"
-        instance2_name = f"test-instance-{util.random_string()}"
+        util.mark("test_ping_between_instances")
+
+        instance1_name = util.generate_instance_name()
+        instance2_name = util.generate_instance_name()
         lxc.launch("images", "alpine/3.10", instance1_name)
         lxc.launch("images", "alpine/3.10", instance2_name)
 
         res = lxc.exec_(instance1_name, ["ping", "-c1", instance2_name])
         self.assertTrue(res.exit_code == 0)
-
-
-if __name__ == '__main__':
-    os.environ["PYLXD_WARNINGS"] = "none"
-    unittest.main()

--- a/yurt/lxc/lxc.py
+++ b/yurt/lxc/lxc.py
@@ -127,7 +127,7 @@ def launch(remote: str, image: str, name: str):
 
         logging.info(f"Starting container")
         instance = util.get_instance(name)
-        instance.start()
+        instance.start(wait=True)
     except LXDAPIException as e:
         logging.error(e)
         raise LXCException(f"Failed to launch instance {name}")


### PR DESCRIPTION
* Make lxc.launch wait for instance to start before returning.
* Silence warnings in pylxd and paramiko