### PR TITLE
Improve consistency in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,34 +59,25 @@ This downloads and imports a virtual appliance file and may take a few minutes t
 We also install a network interface on your host to allow for direct communication with containers. Accept the User Account Control prompt from VirtualBox when it comes up. Initialization will fail if VirtualBox is denied permission.
 
 
-After initialization, yurt will ask if you want to boot the VM. Respond with 'yes' to start the boot process.
-You can also start it later with `yurt boot`.
-
-
 That's all. You are now ready to launch some containers. At this time we support amd64 images from https://images.linuxcontainers.org/ only. Run `yurt images --remote` to view them.
 
 ```
-$ yurt launch alpine/3.11 instance1
-$ yurt launch ubuntu/18.04 instance2
+$ yurt launch alpine/3.11 c1
+$ yurt launch ubuntu/18.04 c2
 $ yurt list
 
 Name       Status    IP Address       Image
 ---------  --------  ---------------  -------------------
-instance1  Running   192.168.132.117  Alpine/3.11 (amd64)
-instance2  Running   192.168.132.92   Ubuntu/bionic (amd64)
+c1  Running   192.168.132.117  Alpine/3.11 (amd64)
+c2  Running   192.168.132.92   Ubuntu/bionic (amd64)
 
 ```
 
-Run `yurt launch --help` for more information about launching containers and `yurt --help` to explore other commands.
+After launching, start a shell in the container with `yurt shell <name>` . The terminal launched by this command is not very sophisticated 
+so it's best to configure a user to SSH with.
 
-After launching, run `yurt shell <instance> ` to proceed with configuration as you would with any other server.
-At this point, it's best to create and configure a user to SSH with.
 
-```
-$ yurt shell instance1
-root@instance1:~ #
-```
-
+See `yurt -h` for more information about the CLI.
 
 ## Contributing
 

--- a/yurt/lxc/lxc.py
+++ b/yurt/lxc/lxc.py
@@ -107,7 +107,7 @@ def launch(remote: str, image: str, name: str):
 
     try:
         logging.info(
-            f"Launching container {name}. This might take a few minutes...")
+            f"Launching container '{name}'. This might take a few minutes...")
         response = client.api.instances.post(json={
             "name": name,
             "profiles": [util.PROFILE_NAME],

--- a/yurt/lxc/util.py
+++ b/yurt/lxc/util.py
@@ -43,7 +43,7 @@ def get_pylxd_client():
     except pylxd.exceptions.ClientConnectionFailed as e:
         logging.debug(e)
         raise LXCException(
-            "Error connecting to LXD. Try rebooting the VM: 'yurt reboot'")
+            "Error connecting to LXD. Try restarting the VM: 'yurt vm restart'")
 
 
 def get_instance(name: str):
@@ -111,7 +111,7 @@ def initialize_lxd():
         config.set_config(config.Key.is_lxd_initialized, True)
     except VMException as e:
         logging.error(e)
-        logging.error("Restart the VM to try again: 'yurt reboot'")
+        logging.error("Restart the VM to try again: 'yurt vm restart'")
         raise LXCException("Failed to initialize LXD.")
 
 

--- a/yurt/vm/__init__.py
+++ b/yurt/vm/__init__.py
@@ -5,6 +5,7 @@ from .vm import (
     ensure_is_ready,
     info,
     init,
+    ssh,
     start,
     state,
     stop,

--- a/yurt/vm/vm.py
+++ b/yurt/vm/vm.py
@@ -127,7 +127,7 @@ def start():
         return
 
     try:
-        logging.info("Booting up...")
+        logging.info("Starting up...")
 
         console_file_name = os.path.join(config.vm_install_dir, "console.log")
         vbox.attach_serial_console(vm_name, console_file_name)
@@ -145,12 +145,12 @@ def start():
 
 def ensure_is_ready(prompt_init=True, prompt_start=True):
     initialize_vm_prompt = "Yurt has not been initialized. Initialize now?"
-    start_vm_prompt = "Yurt is not running. Boot up now?"
+    start_vm_prompt = "Yurt is not running. Start up now?"
 
     if state() == State.NotInitialized:
         if prompt_init:
             initialize_vm = yurt_util.prompt_user(
-                initialize_vm_prompt, ["yes", "no"]) == "yes"
+                initialize_vm_prompt, ["y", "n"]) == "y"
         else:
             initialize_vm = True
 
@@ -168,7 +168,7 @@ def ensure_is_ready(prompt_init=True, prompt_start=True):
 
         if prompt_start:
             start_vm = yurt_util.prompt_user(
-                start_vm_prompt, ["yes", "no"]) == "yes"
+                start_vm_prompt, ["y", "n"]) == "y"
         else:
             start_vm = True
 
@@ -244,6 +244,15 @@ def run_cmd(cmd: str, show_spinner: bool = False, stdin=None):
             return cmd_future.result()
     else:
         return ssh.run_cmd(cmd, stdin=stdin)
+
+
+def ssh():
+    import subprocess
+
+    ssh_port = config.get_config(config.Key.ssh_port)
+    subprocess.run(
+        f"ssh -i {config.ssh_private_key_file} yurt@127.0.0.1 -p {ssh_port}",
+    )
 
 
 def put_file(local_path: str, remote_path: str):


### PR DESCRIPTION
* Bundle VM management commands under 'yurt vm <cmd>' to avoid cluttering
  the top level container management commands.
* Replace 'instance' with 'container' for clarity
* Document and add 'yurt vm ssh' as an escape hatch.